### PR TITLE
Update libxml-ruby version to the latest

### DIFF
--- a/catarse_moip.gemspec
+++ b/catarse_moip.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   s.add_dependency "rails", "~> 3.2.13"
-  s.add_dependency('libxml-ruby', '~> 2.3.3')
+  s.add_dependency('libxml-ruby', '~> 2.6.0')
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails"


### PR DESCRIPTION
I could not install or proceed with my catarse install due to this version failing on OSX.
