### PR TITLE
Update libxml-ruby to 2.8.0

### DIFF
--- a/catarse_moip.gemspec
+++ b/catarse_moip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 4.0"
   s.add_dependency "httparty"
-  s.add_dependency('libxml-ruby', '~> 2.6.0')
+  s.add_dependency 'libxml-ruby', '~> 2.8.0'
   s.add_dependency "enumerate_it"
 
   s.add_development_dependency "rspec-rails", "~> 2.14.0"


### PR DESCRIPTION
Config has been deprecated in ruby 2.2
https://github.com/xml4r/libxml-ruby/commit/0bdfffcdd53a40bd866b10b4692e23da6a020d88
